### PR TITLE
Added optional 'check_path' and 'check_url' parameters to 'spell' and…

### DIFF
--- a/src/pyaspeller/speller.py
+++ b/src/pyaspeller/speller.py
@@ -41,7 +41,12 @@ class Speller:
     Base spell class. Implements spelling logic for files.
     """
 
-    def spell(self, text: str) -> Iterable[object]:
+    def spell(
+            self,
+            text: str,
+            check_path: bool = True,
+            check_url: bool = True,
+    ) -> Iterable[object]:
         """
         Runs spell checking for text or URI and yields suggestions for changes.
 
@@ -56,18 +61,23 @@ class Speller:
         if not isinstance(text, str):
             raise BadArgumentError(f"Unsupported type for {text}")
 
-        if is_path(text):
+        if check_path and is_path(text):
             self.spell_path(text, apply=False)
             return
 
-        if is_url(text):
+        if check_url and is_url(text):
             content = _fetch_content(text)
             yield from self._spell_text(content)
 
         else:
             yield from self._spell_text(text)
 
-    def spelled(self, text: str) -> str:
+    def spelled(
+            self,
+            text: str,
+            check_path: bool = True,
+            check_url: bool = True,
+    ) -> str:
         """
         Runs spell checking and apply suggestions.
 
@@ -77,11 +87,11 @@ class Speller:
         if not isinstance(text, str):
             raise BadArgumentError(f"Unsupported type for {text}")
 
-        if is_path(text):
+        if check_path and is_path(text):
             self.spell_path(text, apply=True)
             return ""
 
-        if is_url(text):
+        if check_url and is_url(text):
             content = _fetch_content(text)
         else:
             content = text


### PR DESCRIPTION
Hello! I use your library for some NLP tasks 

So `spell` and `spelled` methods will check `text` parameter for presence some path or url in it.

```python
if is_path(text):
    self.spell_path(text, apply=True)
    return ""
if is_url(text):
    content = _fetch_content(text)
else:
    content = text
```

It is absolutely useless and not required for me, because `text` parameter will be provided by **users**.

Good solution is creating separated methods, like `spell`, `spell_url` and `spell_path` but, I don't want crash others code, I think optimal solution is creating `check_url` and `check_path` optional parameters (default `True`)


```python
def spell(
        self,
        text: str,
        check_path: bool = True,
        check_url: bool = True,
) -> Iterable[object]:
    """
    Runs spell checking for text or URI and yields suggestions for changes.

    >>> spelled = speller.spell("42 is a cool maagic namber")
    >>> for p in spelled: print(p)
    {'code': 1, 'pos': 12, 'row': 0, 'col': 12, 'len': 6,
        'word': 'maagic', 's': ['magic']}
    {'code': 1, 'pos': 19, 'row': 0, 'col': 19, 'len': 6,
        'word': 'namber', 's': ['number']}

    """
    if not isinstance(text, str):
        raise BadArgumentError(f"Unsupported type for {text}")

    if check_path and is_path(text):
        self.spell_path(text, apply=False)
        return

    if check_url and is_url(text):
        content = _fetch_content(text)
        yield from self._spell_text(content)

    else:
        yield from self._spell_text(text)
```

