### PR TITLE
Add new methods for explicit deal with strings only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [1.1.0] - 2023-02-07
+### Added
+- Add new methods `spell_text` and `spelled_text` for explicit deal with strings only
+- Allow to recieve Pathlib.Path argument
+- Increase test coverage
+
+
 ## [1.0.0] - 2022-12-08
 ### Added
 - Using keep changelog format

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ test:
 	$(VENV)/bin/pytest tests --cov=src --ignore=.DS_Store
 
 coverage-report:
-	$(VENV)/bin/coverage report -m
+	$(VENV)/bin/pytest tests --cov=src --cov-report html
 
 clean:
 	rm -rf `find . -name __pycache__`

--- a/poetry.lock
+++ b/poetry.lock
@@ -372,6 +372,30 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
+name = "requests-mock"
+version = "1.10.0"
+description = "Mock out responses from the requests package"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+requests = ">=2.3,<3"
+six = "*"
+
+[package.extras]
+fixture = ["fixtures"]
+test = ["fixtures", "mock", "purl", "pytest", "requests-futures", "sphinx", "testrepository (>=0.0.18)", "testtools"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
 name = "tomli"
 version = "1.2.3"
 description = "A lil' TOML parser"
@@ -423,7 +447,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "a2c36f0d660c26cf91cf7985dbdcbbb15c4a82607e3b54a14d6fb547450af71c"
+content-hash = "f480a79fdac4b31c2d6a8b6799909610c3278c058d733c3f42f28154af22b04b"
 
 [metadata.files]
 atomicwrites = [
@@ -635,6 +659,14 @@ pytest-deadfixtures = [
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
+]
+requests-mock = [
+    {file = "requests-mock-1.10.0.tar.gz", hash = "sha256:59c9c32419a9fb1ae83ec242d98e889c45bd7d7a65d48375cc243ec08441658b"},
+    {file = "requests_mock-1.10.0-py2.py3-none-any.whl", hash = "sha256:2fdbb637ad17ee15c06f33d31169e71bf9fe2bdb7bc9da26185be0dd8d842699"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 tomli = [
     {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyaspeller"
-version = "1.0.0"
+version = "1.1.0"
 description = "Search tool typos in the text, files and websites."
 authors = [
     "Vassiliy Taranov <taranov.vv@gmail.com>",
@@ -47,6 +47,7 @@ mypy = "^0.971"
 pytest = "^7.0.1"
 pytest-cov = "^4.0.0"
 pytest-deadfixtures = "^2.2.1"
+requests-mock = "^1.10.0"
 
 
 [build-system]

--- a/src/pyaspeller/__init__.py
+++ b/src/pyaspeller/__init__.py
@@ -9,7 +9,7 @@ from .speller import Speller  # noqa
 from .word import Word  # noqa
 from .yandex_speller import YandexSpeller  # noqa
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __all__ = ["main"]
 
 
@@ -123,7 +123,7 @@ def _create_speller(args) -> YandexSpeller:
     return speller
 
 
-def main():
+def main():  # "pragma: no cover",
     """
     Main function. Uses as cli launcher
     """

--- a/src/pyaspeller/speller.py
+++ b/src/pyaspeller/speller.py
@@ -4,7 +4,8 @@ Contains definitions of spellers.
 from __future__ import annotations
 import logging
 import os
-from typing import Iterable
+from typing import Iterable, Union
+from pathlib import Path
 
 import requests
 
@@ -32,7 +33,7 @@ def is_url(text: str) -> bool:
     return text.startswith(("http://", "https://"))
 
 
-def is_path(path: str) -> bool:
+def is_path(path: Union[str, Path]) -> bool:
     return os.path.exists(path)
 
 
@@ -53,7 +54,7 @@ class Speller:
             'word': 'namber', 's': ['number']}
 
         """
-        if not isinstance(text, str):
+        if not isinstance(text, (str, Path)):
             raise BadArgumentError(f"Unsupported type for {text}")
 
         if is_path(text):
@@ -74,7 +75,7 @@ class Speller:
         >>> result = speller.spelled("tesst message")
         >>> assert result == 'test message'
         """
-        if not isinstance(text, str):
+        if not isinstance(text, (str, Path)):
             raise BadArgumentError(f"Unsupported type for {text}")
 
         if is_path(text):
@@ -115,6 +116,19 @@ class Speller:
         content = _fetch_content(url)
         changes = self._spell_text(content)
         return self._apply_suggestion(content, changes)
+
+    def spelled_text(self, text: str) -> str:
+        """
+        Run spell checking and apply suggestions for text.
+        """
+        changes = self._spell_text(text)
+        return self._apply_suggestion(text, changes)
+
+    def spell_text(self, text: str) -> list[dict]:
+        """
+        Run spell checking for text.
+        """
+        return self._spell_text(text)
 
     def _spell_text(self, text: str) -> list[dict]:
         raise NotImplementedError()


### PR DESCRIPTION
New methods are `spell_text` and `spelled_text`. They shouldn't deal with network requests and os.path