### PR TITLE
Hotfix/encoding problems when reading and writing file on windows.

### DIFF
--- a/src/pyaspeller/speller.py
+++ b/src/pyaspeller/speller.py
@@ -136,14 +136,14 @@ class Speller:
     def _apply_suggestion(self, text: str, changes: Iterable[dict]) -> str:
         raise NotImplementedError()
 
-    def _spell_file(self, path: str, apply: bool) -> Iterable[dict]:
-        with open(path) as infile:
+    def _spell_file(self, path: str, apply: bool, encoding: str = 'utf-8') -> Iterable[dict]:
+        with open(path, encoding=encoding) as infile:
             content = infile.read()
             changes = self._spell_text(content)
 
             if apply:
                 updated = self._apply_suggestion(content, changes)
-                with open(path, "w") as outfile:
+                with open(path, "w", encoding=encoding) as outfile:
                     outfile.write(updated)
             else:
                 yield from changes


### PR DESCRIPTION
I had this kind `UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 11: character maps to <undefined>` of problems reading a 'utf-8' encoded file on Windows. 

So in order to make as small changes as possible I added default parameter to `_spell_file()` function.