### PR TITLE
Hotfix/encoding problems when reading and writing file on windows

### DIFF
--- a/src/pyaspeller/speller.py
+++ b/src/pyaspeller/speller.py
@@ -42,7 +42,7 @@ class Speller:
     Base spell class. Implements spelling logic for files.
     """
 
-    def spell(self, text: str) -> Iterable[object]:
+    def spell(self, text: str, encoding: str = None) -> Iterable[object]:
         """
         Runs spell checking for text or URI and yields suggestions for changes.
 
@@ -58,7 +58,7 @@ class Speller:
             raise BadArgumentError(f"Unsupported type for {text}")
 
         if is_path(text):
-            self.spell_path(text, apply=False)
+            self.spell_path(text, apply=False, encoding=encoding)
             return
 
         if is_url(text):
@@ -68,7 +68,7 @@ class Speller:
         else:
             yield from self._spell_text(text)
 
-    def spelled(self, text: str) -> str:
+    def spelled(self, text: str, encoding: str = None) -> str:
         """
         Runs spell checking and apply suggestions.
 
@@ -79,7 +79,7 @@ class Speller:
             raise BadArgumentError(f"Unsupported type for {text}")
 
         if is_path(text):
-            self.spell_path(text, apply=True)
+            self.spell_path(text, apply=True, encoding=encoding)
             return ""
 
         if is_url(text):
@@ -90,7 +90,7 @@ class Speller:
         changes = self._spell_text(content)
         return self._apply_suggestion(content, changes)
 
-    def spell_path(self, path: str, apply: bool) -> None:
+    def spell_path(self, path: str, apply: bool, encoding: str = None) -> None:
         """
         Traverse through path and apply spelling
         """
@@ -100,14 +100,14 @@ class Speller:
 
         if os.path.isfile(path):
             # iterate over changes
-            list(self._spell_file(path, apply))
+            list(self._spell_file(path, apply, encoding=encoding))
             return
 
         for root, _, fnames in os.walk(path):
             for fname in fnames:
                 fullpath = os.path.join(root, fname)
                 # iterate over changes
-                list(self._spell_file(fullpath, apply))
+                list(self._spell_file(fullpath, apply, encoding=encoding))
 
     def spell_url(self, url: str) -> str:
         """
@@ -136,7 +136,7 @@ class Speller:
     def _apply_suggestion(self, text: str, changes: Iterable[dict]) -> str:
         raise NotImplementedError()
 
-    def _spell_file(self, path: str, apply: bool, encoding: str = 'utf-8') -> Iterable[dict]:
+    def _spell_file(self, path: str, apply: bool, encoding: str = None) -> Iterable[dict]:
         with open(path, encoding=encoding) as infile:
             content = infile.read()
             changes = self._spell_text(content)

--- a/src/pyaspeller/speller.py
+++ b/src/pyaspeller/speller.py
@@ -136,14 +136,14 @@ class Speller:
     def _apply_suggestion(self, text: str, changes: Iterable[dict]) -> str:
         raise NotImplementedError()
 
-    def _spell_file(self, path: str, apply: bool) -> Iterable[dict]:
-        with open(path) as infile:
+    def _spell_file(self, path: str, apply: bool, encoding: str = 'utf-8') -> Iterable[dict]:
+        with open(path, encoding=encoding) as infile:
             content = infile.read()
             changes = self._spell_text(content)
 
             if apply:
                 updated = self._apply_suggestion(content, changes)
-                with open(path, "w") as outfile:
+                with open(path, "w", encoding=encoding) as outfile:
                     outfile.write(updated)
             else:
                 yield from changes


### PR DESCRIPTION
I had this kind `UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 11: character maps to <undefined>` of problems reading a `utf-8` encoded file on Windows.

So in order to make as small changes as possible I added default parameter `encoding` to `_spell_file()` function.

But in order to gain control and yet to follow Python `open` function standard behaviour I kept default argument of `encoding` set to `None`, so 

> The default encoding is platform dependent (whatever [locale.getencoding()](https://docs.python.org/3/library/locale.html#locale.getencoding) returns), but any [text encoding](https://docs.python.org/3/glossary.html#term-text-encoding) supported by Python can be used. 

as it is said in the [docs](https://docs.python.org/3/library/functions.html#open).